### PR TITLE
feat(level_button): 修改按钮大小并添加两位数显示

### DIFF
--- a/levels/base_level/base_level.tscn
+++ b/levels/base_level/base_level.tscn
@@ -57,7 +57,7 @@ script = ExtResource("1_diojb")
 [node name="BackButton" parent="HUDs" instance=ExtResource("2_0egdl")]
 
 [node name="icon" type="AnimatedSprite2D" parent="HUDs/BackButton"]
-position = Vector2(8, 8)
+position = Vector2(5, 5)
 sprite_frames = SubResource("SpriteFrames_yulkh")
 animation = &"return"
 centered = false
@@ -72,11 +72,11 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="ReplayButton" parent="HUDs" instance=ExtResource("2_0egdl")]
-offset_left = 440.0
+offset_left = 446.0
 offset_right = 480.0
 
 [node name="icon" type="AnimatedSprite2D" parent="HUDs/ReplayButton"]
-position = Vector2(6, 6)
+position = Vector2(3, 3)
 sprite_frames = SubResource("SpriteFrames_5hm0m")
 animation = &"replay"
 centered = false

--- a/levels/chapter_menu/level_menu/level_button/level_button.gd
+++ b/levels/chapter_menu/level_menu/level_button/level_button.gd
@@ -10,8 +10,19 @@ var button_type = 0 # type = 0 表示为选择章节的按钮， type = 1 表示
 
 
 func set_word(value: String) -> void:
-	$Word.set_word(value)
-	
+	if value.length() == 1:
+		$Word.set_word(value)
+		$Word.visible = true
+		$Word1.visible = false
+		$Word2.visible = false
+	elif value.length() == 2:
+		$Word1.set_word(value[0])
+		$Word2.set_word(value[1])
+		$Word.visible = false
+		$Word1.visible = true
+		$Word2.visible = true
+	else:
+		push_error("level button set_word error: ", value)
 
 func init(chapter_id: int, level_id : int, pos : Vector2, type : int) -> void :
 	chap_id = chapter_id
@@ -19,7 +30,7 @@ func init(chapter_id: int, level_id : int, pos : Vector2, type : int) -> void :
 
 	var txt
 	if type == 0:
-		txt = "I" + str(chapter_id + 1)
+		txt = str(chapter_id + 1)
 	else:
 		txt = str(level_id + 1)
 	set_word(txt)

--- a/levels/chapter_menu/level_menu/level_button/level_button.tscn
+++ b/levels/chapter_menu/level_menu/level_button/level_button.tscn
@@ -5,11 +5,17 @@
 [ext_resource type="PackedScene" uid="uid://cvx7wowcbfo0r" path="res://objects/word/word.tscn" id="3_js2i2"]
 
 [node name="LevelButton" instance=ExtResource("1_4bgxw")]
-offset_right = 40.0
-offset_bottom = 40.0
+offset_right = 34.0
+offset_bottom = 34.0
 script = ExtResource("1_wwqfn")
 
 [node name="Word" parent="." index="0" instance=ExtResource("3_js2i2")]
-position = Vector2(19, 19)
-scale = Vector2(1.5, 1.5)
-text_id = 0
+position = Vector2(17, 17)
+
+[node name="Word1" parent="." index="2" instance=ExtResource("3_js2i2")]
+visible = false
+position = Vector2(11, 17)
+
+[node name="Word2" parent="." index="3" instance=ExtResource("3_js2i2")]
+visible = false
+position = Vector2(23, 17)

--- a/levels/chapter_menu/level_menu/level_menu.tscn
+++ b/levels/chapter_menu/level_menu/level_menu.tscn
@@ -30,7 +30,7 @@ script = ExtResource("1_sd65g")
 [node name="BackButton" parent="." instance=ExtResource("2_saprs")]
 
 [node name="icon" type="AnimatedSprite2D" parent="BackButton"]
-position = Vector2(8, 8)
+position = Vector2(5, 5)
 sprite_frames = SubResource("SpriteFrames_waq31")
 animation = &"return"
 centered = false


### PR DESCRIPTION
修改：

- 将大小缩放还原为 1x（由于 1.5x 缩放会导致素材被错误地抗锯齿）。
- 为 void set_word(value: String) 添加显示两位数的功能，只需要令传入 value 长度为 2 即可。
  此外，删除了设置按钮显示罗马数字的功能，暂不提供替代方案。

BREAKING CHANGE: 修改了 LevelButton 的大小，删除设置罗马数字功能。

暂不提供替代方案。

**注**：之后 UI 如果有更新可以改按钮大小，我只是为了去掉 1.5x 导致的缩放问题才设置按钮为原大小。