### PR TITLE
feat: 添加动态淡入淡出切换主题配色功能

### DIFF
--- a/bg/dynamic_bg/dynamic_bg_pattern/dynamic_bg_pattern.gd
+++ b/bg/dynamic_bg/dynamic_bg_pattern/dynamic_bg_pattern.gd
@@ -11,8 +11,8 @@ func _ready():
 	else:
 		$Word1.set_word("qd<"[randi_range(0, 2)])
 		$Word2.set_word("=*"[randi_range(0, 1)])
-	$Word1.set_color(ImageLib.get_palette_color_by_name("mid"))
-	$Word2.set_color(ImageLib.get_palette_color_by_name("mid"))
+	$Word1.set_color(ImageLib.get_palette_color_by_info("blue", "mid"))
+	$Word2.set_color(ImageLib.get_palette_color_by_info("blue", "mid"))
 
 func _process(delta):
 	position += velocity * delta
@@ -21,9 +21,9 @@ func _process(delta):
 
 func _on_victory_change(v: bool):
 	if v:
-		$Word1.set_color(ImageLib.get_palette_color_by_name("light"))
-		$Word2.set_color(ImageLib.get_palette_color_by_name("light"))
+		$Word1.set_color(ImageLib.get_palette_color_by_info("blue", "light"))
+		$Word2.set_color(ImageLib.get_palette_color_by_info("blue", "light"))
 	else:
-		$Word1.set_color(ImageLib.get_palette_color_by_name("mid"))
-		$Word2.set_color(ImageLib.get_palette_color_by_name("mid"))
+		$Word1.set_color(ImageLib.get_palette_color_by_info("blue", "mid"))
+		$Word2.set_color(ImageLib.get_palette_color_by_info("blue", "mid"))
 

--- a/levels/chapter_menu/level_menu/level_menu.gd
+++ b/levels/chapter_menu/level_menu/level_menu.gd
@@ -2,7 +2,6 @@ extends Node2D
 
 class_name LevelMenu
 
-# const I_NUMBER = ["I","II","III","VI","V"]
 
 const LevelButtonScn := preload("res://levels/chapter_menu/level_menu/level_button/level_button.tscn")
 const BaseLevelScn := preload("res://levels/base_level/base_level.tscn")
@@ -44,12 +43,14 @@ func _on_button_enter_level(chap_id: int, lvl_id: int) -> void:
 func _on_previous_chapter_button_pressed():
 	self.chapter_id -= 1
 	$UI/Title.text = LevelData.CHAP_NAMES[chapter_id]["name-en"]
+	ImageLib.change_theme(ImageLib.COLOR_THEMES[ImageLib.COLOR_THEMES.find(ImageLib.theme_to) - 1], LevelMenuCamera.MOVE_TIME)
 	$UI/PreviousChapterButton.set_disabled(true)
 	$UI/NextChapterButton.set_disabled(true)
 
 
 func _on_next_chapter_button_pressed():
 	self.chapter_id += 1
+	ImageLib.change_theme(ImageLib.COLOR_THEMES[ImageLib.COLOR_THEMES.find(ImageLib.theme_to) + 1], LevelMenuCamera.MOVE_TIME)
 	$UI/Title.text = LevelData.CHAP_NAMES[chapter_id]["name-en"]
 	$UI/PreviousChapterButton.set_disabled(true)
 	$UI/NextChapterButton.set_disabled(true)

--- a/main.gd
+++ b/main.gd
@@ -1,6 +1,9 @@
 class_name Main extends Node
 
 
+func _ready():
+	ImageLib.init()
+
 
 func _on_main_menu_enter_level():
 	$BGMPlayer.play()
@@ -9,4 +12,4 @@ func _on_main_menu_enter_level():
 func _on_bgm_player_finished():
 	$BGMPlayer.play()
 func set_victory(v: bool):
-	$DynamicBg.set_victory(v)
+	$UI/DynamicBg.set_victory(v)

--- a/main.tscn
+++ b/main.tscn
@@ -1,27 +1,41 @@
-[gd_scene load_steps=6 format=3 uid="uid://c17fbsiogbgo1"]
+[gd_scene load_steps=8 format=3 uid="uid://c17fbsiogbgo1"]
 
 [ext_resource type="PackedScene" uid="uid://c07co5p46apu7" path="res://objects/main_menu/main_menu.tscn" id="1_fk6j6"]
 [ext_resource type="Script" path="res://main.gd" id="1_nb6uf"]
 [ext_resource type="PackedScene" uid="uid://d3geq38s5fjc6" path="res://bg/dynamic_bg/dynamic_bg.tscn" id="2_8k4il"]
+[ext_resource type="PackedScene" uid="uid://budvuitfjtjcd" path="res://scripts/image_lib/image_lib.tscn" id="2_771gm"]
 [ext_resource type="AudioStream" uid="uid://cr3nkhf0fejm5" path="res://levels/base_level/bgm.wav" id="3_n81it"]
 [ext_resource type="PackedScene" uid="uid://prht3u5pnjls" path="res://scripts/cursor_manager/cursor_manager.tscn" id="5_pqych"]
+[ext_resource type="Material" uid="uid://rywrg5id25dr" path="res://shaders/main_shader.tres" id="6_tvi4r"]
 
 [node name="Main" type="Node"]
 script = ExtResource("1_nb6uf")
 
-[node name="DynamicBg" parent="." instance=ExtResource("2_8k4il")]
-offset_right = 0.0
-offset_bottom = 0.0
+[node name="ImageLib" parent="." instance=ExtResource("2_771gm")]
 
 [node name="MainMenu" parent="." instance=ExtResource("1_fk6j6")]
 
-[node name="BGMPlayer" type="AudioStreamPlayer2D" parent="."]
-position = Vector2(234, 150)
+[node name="BGMPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("3_n81it")
 volume_db = -4.685
-attenuation = 0.0001
 
 [node name="CursorManager" parent="." instance=ExtResource("5_pqych")]
 
-[connection signal="enter_level" from="MainMenu" to="." method="_on_main_menu_enter_level"]
-[connection signal="finished" from="BGMPlayer" to="." method="_on_bgm_player_finished"]
+[node name="UI" type="CanvasLayer" parent="."]
+layer = -1
+
+[node name="DynamicBg" parent="UI" instance=ExtResource("2_8k4il")]
+offset_right = 0.0
+offset_bottom = 0.0
+
+[node name="ScreenShader" type="CanvasLayer" parent="."]
+layer = 100
+
+[node name="ShaderRect" type="ColorRect" parent="ScreenShader"]
+material = ExtResource("6_tvi4r")
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2

--- a/objects/card/card.gd
+++ b/objects/card/card.gd
@@ -111,7 +111,7 @@ func set_word(value: String) -> void:
 	ImageLib.update_animation(
 		$CardBackSprite, 1, 3, 1, "res://objects/card/card%d.png",
 		ImageLib.get_palette_color_by_info("blue", "light"),
-		ImageLib.get_palette_color_by_name(new_color_name)
+		ImageLib.get_palette_color_by_info("blue", new_color_name)
 	)
 
 

--- a/objects/card_base/card_base.gd
+++ b/objects/card_base/card_base.gd
@@ -71,10 +71,8 @@ func set_word(e: String) -> void:
 	ImageLib.update_animation(
 		$CardBaseSprite, 1, 3, 1, "res://objects/card_base/card_base.png",
 		ImageLib.get_palette_color_by_info("blue", "light"),
-		ImageLib.get_palette_color_by_name(new_color_name)
+		ImageLib.get_palette_color_by_info("blue", new_color_name)
 	)
-	
-	$DisabledSprite.texture = ImageLib.replace_palette_colors_in_image($DisabledSprite.texture)
 	
 
 ## 获取字符。

--- a/objects/styled_button/styled_button.gd
+++ b/objects/styled_button/styled_button.gd
@@ -5,11 +5,3 @@ class_name StyledButton
 
 func _on_pressed():
 	$SFXButtonDown.play()
-
-
-func _ready():
-	for box_theme in ["normal", "hover", "presssed", "disabled", "focus"]:
-		var stylebox := get_theme_stylebox(box_theme)
-		if stylebox is StyleBoxTexture:
-			stylebox.texture = ImageLib.replace_palette_colors_in_image(stylebox.texture)
-			add_theme_stylebox_override(box_theme, stylebox)

--- a/objects/table_cloth/table_cloth.gd
+++ b/objects/table_cloth/table_cloth.gd
@@ -1,7 +1,0 @@
-extends Panel
-
-
-func _ready():
-	var stylebox := get_theme_stylebox("panel")
-	stylebox.texture = ImageLib.replace_palette_colors_in_image(stylebox.texture)
-	add_theme_stylebox_override("panel", stylebox)

--- a/objects/table_cloth/table_cloth.tscn
+++ b/objects/table_cloth/table_cloth.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://7kd53bu4qorc"]
+[gd_scene load_steps=5 format=3 uid="uid://7kd53bu4qorc"]
 
 [ext_resource type="Texture2D" uid="uid://1gcwvbyjejey" path="res://objects/table_cloth/table_cloth.png" id="1_8qui1"]
 [ext_resource type="Texture2D" uid="uid://cb5gytqlvjj2v" path="res://objects/table_cloth/golden_cloth.png" id="2_3edv5"]
-[ext_resource type="Script" path="res://objects/table_cloth/table_cloth.gd" id="2_wo6il"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_js8qc"]
 texture = ExtResource("1_8qui1")
@@ -24,7 +23,6 @@ offset_right = 109.0
 offset_bottom = 40.0
 mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxTexture_js8qc")
-script = ExtResource("2_wo6il")
 
 [node name="GoldenCloth" type="Panel" parent="."]
 visible = false

--- a/objects/word/word.gd
+++ b/objects/word/word.gd
@@ -41,7 +41,7 @@ func set_text_id(value: int) -> void:
 
 ## 根据当前的 [member text_id] 更新动画。
 func update_animation() -> void:
-	ImageLib.update_animation(self, text_id + 1, 3, STEP, "res://objects/word/sprites/sprite%d.png", Color.BLACK, self.color)
+	ImageLib.update_animation(self, text_id + 1, 3, STEP, "res://objects/word/sprites/sprite%d.png")
 	
 	
 
@@ -63,8 +63,8 @@ func get_word() -> String:
 
 ## 设置字符颜色为 [param value] 并更新动画。
 func set_color(value: Color) -> void:
-	color = value
-	update_animation()
+	self.color = value
+	self.material.set_shader_parameter("color", value)
 
 
 ## 设置是否为关卡通过状态。
@@ -83,3 +83,4 @@ func set_victory(v: bool) -> void:
 
 func _ready():
 	update_animation()
+	set_color(self.color)

--- a/objects/word/word.gdshader
+++ b/objects/word/word.gdshader
@@ -1,0 +1,8 @@
+shader_type canvas_item;
+
+uniform vec4 color : source_color;
+
+void fragment() {
+	COLOR = texture(TEXTURE, UV);
+	COLOR.rgb = color.rgb;
+}

--- a/objects/word/word.tscn
+++ b/objects/word/word.tscn
@@ -1,7 +1,13 @@
-[gd_scene load_steps=4 format=3 uid="uid://cvx7wowcbfo0r"]
+[gd_scene load_steps=6 format=3 uid="uid://cvx7wowcbfo0r"]
 
 [ext_resource type="Texture2D" uid="uid://cyyu6tsje4x72" path="res://objects/word/sprites/sprite3.png" id="1_ariam"]
 [ext_resource type="Script" path="res://objects/word/word.gd" id="1_lkxlh"]
+[ext_resource type="Shader" path="res://objects/word/word.gdshader" id="1_n15m3"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_bx5kk"]
+resource_local_to_scene = true
+shader = ExtResource("1_n15m3")
+shader_parameter/color = null
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_3n85j"]
 animations = [{
@@ -15,5 +21,6 @@ animations = [{
 }]
 
 [node name="Word" type="AnimatedSprite2D"]
+material = SubResource("ShaderMaterial_bx5kk")
 sprite_frames = SubResource("SpriteFrames_3n85j")
 script = ExtResource("1_lkxlh")

--- a/scripts/image_lib/image_lib.tscn
+++ b/scripts/image_lib/image_lib.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://budvuitfjtjcd"]
+
+[ext_resource type="Script" path="res://scripts/image_lib/image_lib.gd" id="1_ye06g"]
+
+[node name="ImageLib" type="Node"]
+script = ExtResource("1_ye06g")

--- a/shaders/main_shader.gdshader
+++ b/shaders/main_shader.gdshader
@@ -1,0 +1,26 @@
+shader_type canvas_item;
+
+uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear_mipmap;
+
+uniform vec4 blue_lightest = vec4(-1);
+uniform vec4 blue_light = vec4(-1);
+uniform vec4 blue_mid = vec4(-1);
+uniform vec4 blue_darkest = vec4(-1);
+uniform vec4 theme_lightest = vec4(-1);
+uniform vec4 theme_light = vec4(-1);
+uniform vec4 theme_mid = vec4(-1);
+uniform vec4 theme_darkest = vec4(-1);
+
+void fragment() {
+	vec4 col = texture(SCREEN_TEXTURE, SCREEN_UV);
+	if (col == blue_lightest)
+		COLOR = theme_lightest;
+	else if (col == blue_light)
+		COLOR = theme_light;
+	else if (col == blue_mid)
+		COLOR = theme_mid;
+	else if (col == blue_darkest)
+		COLOR = theme_darkest;
+	else
+		COLOR = col;
+}

--- a/shaders/main_shader.tres
+++ b/shaders/main_shader.tres
@@ -1,0 +1,14 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://rywrg5id25dr"]
+
+[ext_resource type="Shader" path="res://shaders/main_shader.gdshader" id="1_y6u4q"]
+
+[resource]
+shader = ExtResource("1_y6u4q")
+shader_parameter/blue_lightest = Vector4(-1, -1, -1, -1)
+shader_parameter/blue_light = Vector4(-1, -1, -1, -1)
+shader_parameter/blue_mid = Vector4(-1, -1, -1, -1)
+shader_parameter/blue_darkest = Vector4(-1, -1, -1, -1)
+shader_parameter/theme_lightest = Vector4(-1, -1, -1, -1)
+shader_parameter/theme_light = Vector4(-1, -1, -1, -1)
+shader_parameter/theme_mid = Vector4(-1, -1, -1, -1)
+shader_parameter/theme_darkest = Vector4(-1, -1, -1, -1)


### PR DESCRIPTION
https://github.com/ligen131/equal_to_p/commit/fa2bf221953b0f93aed5758f40b363930974129a ：

```plain
新增：

- $/Main/ScreenShader/ShaderRect : ColorRect：实现整个屏幕换色的 shader。

    ShaderRect 会加载 res://shaders/main_shader.tres 和
    res://shaders/main_shader.gdshader，该 shader 会作用于整个屏幕，将
    对应 PALETTE 里的颜色进行替换。

    只需要将 res://shaders/main_shader.tres 中的颜色进行更改，配色就会
    更改。

- $/Main/ImageLib : Node：实现动态淡入淡出时，ImageLib 主题配色更新。

    具体地说，是维护计时器 ImageLib.timer 并进行配色更新。

使用 void ImageLib.change_theme(new_theme: String, duration: float) 即可
动态淡出配色到新主题 new_theme。

BREAKING CHANGE: 废除 ImageLib 的 replace_palette_colors_in_image 函数。
```